### PR TITLE
Add asPhpString() method

### DIFF
--- a/tests/VarDumperTest.php
+++ b/tests/VarDumperTest.php
@@ -45,6 +45,7 @@ class VarDumperTest extends TestCase
 
     /**
      * Data provider for [[testExport()]].
+     *
      * @return array test data
      */
     public function dataProviderExport(): array
@@ -155,6 +156,42 @@ RESULT;
         $exportResult = VarDumper::create($var)->export();
         $this->assertEqualsWithoutLE($expectedResult, $exportResult);
         //$this->assertEquals($var, eval('return ' . $exportResult . ';'));
+    }
+
+    /**
+     * @dataProvider asPhpStringDataProvider
+     *
+     * @param mixed $var
+     * @param string $expectedResult
+     */
+    public function testAsPhpString($var, $expectedResult): void
+    {
+        $exportResult = VarDumper::create($var)->asPhpString();
+        $this->assertEqualsWithoutLE($expectedResult, $exportResult);
+    }
+
+    public function asPhpStringDataProvider(): array
+    {
+        return [
+            [
+                // @formatter:off
+                static fn (VarDumper $date) => new \DateTimeZone(''),
+                // @formatter:on
+                "static fn (VarDumper \$date) => new \DateTimeZone('')",
+            ],
+            [
+                // @formatter:off
+                 static function () {return 2;},
+                // @formatter:on
+                'static function () {return 2;}',
+            ],
+            [
+                // @formatter:off
+                static fn () => 2,
+                // @formatter:on
+                'static fn () => 2',
+            ],
+        ];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | 

New function can export any possible value "as is".
For the most part, the difference from `export` is only in the export of closures.
Nos function `fn (ContainerInterface $container) => ...` will export as is but I soon add ability to specify full namespace name and `fn (ContainerInterface $container) => ...` will be encoded to `fn (\Psr\Container\ContainerInterface $container) => ...`