### PR TITLE
Add full class name substitution in closures

### DIFF
--- a/src/UseStatementParser.php
+++ b/src/UseStatementParser.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\VarDumper;
+
+class UseStatementParser
+{
+    public function fromFile(string $file): array
+    {
+        $tokens = token_get_all(file_get_contents($file));
+        array_shift($tokens);
+
+        $uses = [];
+        foreach ($tokens as $i => $token) {
+            if (!isset($token[0])) {
+                continue;
+            }
+
+            if ($token[0] === T_USE) {
+                array_push($uses, ...$this->normalizeUse(array_slice($tokens, $i + 1)));
+                continue;
+            }
+
+        }
+
+        return $uses;
+    }
+
+    private function normalizeUse(array $tokens): array
+    {
+        /**
+         * use Yiisoft\Arrays\ArrayHelper;
+         * use Yiisoft\Arrays\ArrayHelper, Yiisoft\Arrays\ArraySorter;
+         * use Yiisoft\{Arrays\ArrayHelper, Arrays\ArrayableTrait};
+         * use Yiisoft\{Arrays\ArrayHelper, Arrays\ArrayableTrait}, Yiisoft\Arrays\ArraySorter;
+         */
+        $parentNamespace = '\\';
+        $useParts = [];
+        $pendingParenthesisCount = 0;
+
+        foreach ($tokens as $token) {
+            if ($token === ';') {
+                break;
+            }
+            if (!isset($token[0])) {
+                continue;
+            }
+            if ($token[0] === T_STRING || $token[0] === T_NS_SEPARATOR) {
+                $parentNamespace .= $token[1];
+                continue;
+            }
+//            if ($token[1] === '{') {
+//                $pendingParenthesisCount++;
+//                continue;
+//            }
+//
+//            if ($token[1] === '}') {
+//                $pendingParenthesisCount--;
+//                if ($pendingParenthesisCount === 0) {
+//                    $parentNamespace = '';
+//                }
+//                continue;
+//            }
+
+//            $useParts[] = $token[1];
+        }
+//        var_dump($useParts);
+//        exit();
+
+//        var_dump($parentNamespace . implode('', array_filter($useParts)));
+//        exit();
+        return [$parentNamespace];
+//        return [$parentNamespace . implode('', array_filter($useParts))];
+    }
+}

--- a/src/UseStatementParser.php
+++ b/src/UseStatementParser.php
@@ -76,7 +76,7 @@ class UseStatementParser
                 $alias = mb_substr($use, $delimiterPosition + 1);
                 $result[$alias] = mb_substr($use, 0, $delimiterPosition);
             } else {
-                $result[] = $use;
+                $result[substr(strrchr($use, "\\"), 1)] = $use;
             }
         }
 

--- a/src/UseStatementParser.php
+++ b/src/UseStatementParser.php
@@ -21,7 +21,6 @@ class UseStatementParser
                 array_push($uses, ...$this->normalizeUse(array_slice($tokens, $i + 1)));
                 continue;
             }
-
         }
 
         return $uses;
@@ -35,42 +34,59 @@ class UseStatementParser
          * use Yiisoft\{Arrays\ArrayHelper, Arrays\ArrayableTrait};
          * use Yiisoft\{Arrays\ArrayHelper, Arrays\ArrayableTrait}, Yiisoft\Arrays\ArraySorter;
          */
-        $parentNamespace = '\\';
-        $useParts = [];
+        $commonNamespace = '\\';
+        $tempNamespace = '';
+        $uses = [];
         $pendingParenthesisCount = 0;
 
         foreach ($tokens as $token) {
-            if ($token === ';') {
-                break;
-            }
             if (!isset($token[0])) {
                 continue;
             }
             if ($token[0] === T_STRING || $token[0] === T_NS_SEPARATOR) {
-                $parentNamespace .= $token[1];
+                $commonNamespace .= $token[1];
                 continue;
             }
-//            if ($token[1] === '{') {
-//                $pendingParenthesisCount++;
-//                continue;
-//            }
-//
-//            if ($token[1] === '}') {
-//                $pendingParenthesisCount--;
-//                if ($pendingParenthesisCount === 0) {
-//                    $parentNamespace = '';
-//                }
-//                continue;
-//            }
+            //            if ($pendingParenthesisCount === 0) {
+            //                $commonNamespace .= $token[1];
+            //            }
+            if ($token === ',' || $token === ';') {
+                if ($pendingParenthesisCount === 0) {
+                    $uses[] = $commonNamespace;
+                    $commonNamespace = '\\';
+                }
+            }
+            if ($token === ';') {
+                break;
+            }
+            //            if ($token[1] === '{') {
+            //                $pendingParenthesisCount++;
+            //                continue;
+            //            }
+            //
+            //            if ($token[1] === '}') {
+            //            $pendingParenthesisCount--;
+            //            if ($pendingParenthesisCount === 0) {
+            //                    $commonNamespace = '';
+            //                }
+            //                continue;
+            //            }
 
-//            $useParts[] = $token[1];
+            //            if ($token[0] === T_STRING) {
+            //                $uses[] = $token[1];
+            //            }
         }
-//        var_dump($useParts);
-//        exit();
+        //        var_dump($uses);
+        //        exit();
 
-//        var_dump($parentNamespace . implode('', array_filter($useParts)));
-//        exit();
-        return [$parentNamespace];
-//        return [$parentNamespace . implode('', array_filter($useParts))];
+        //        var_dump($commonNamespace . implode('', array_filter($uses)));
+        //        exit();
+        //        return [$commonNamespace];
+
+        if (!empty($uses)) {
+            return $uses;
+        }
+
+        return [$commonNamespace];
     }
 }

--- a/src/VarDumper.php
+++ b/src/VarDumper.php
@@ -452,7 +452,7 @@ final class VarDumper
         return $this->export();
     }
 
-    public function getUsesParser(): UseStatementParser
+    private function getUsesParser(): UseStatementParser
     {
         if ($this->useStatementParser === null) {
             $this->useStatementParser = new UseStatementParser();

--- a/src/VarDumper.php
+++ b/src/VarDumper.php
@@ -250,7 +250,9 @@ final class VarDumper
                 $spaces = str_repeat(' ', $level * 4);
                 $output .= '[';
                 foreach ($keys as $key) {
-                    $this->beautify && $output .= "\n" . $spaces . '    ';
+                    if ($this->beautify) {
+                        $output .= "\n" . $spaces . '    ';
+                    }
                     $output .= $this->dumpInternal($key, $depth, 0);
                     $output .= ' => ';
                     $output .= $this->dumpInternal($var[$key], $depth, $level + 1);
@@ -336,7 +338,6 @@ final class VarDumper
                         $output .= ' => ';
                     }
                     $output .= $this->exportInternal($var[$key], $level + 1);
-                    var_dump($output);
                     if ($this->beautify || next($keys) !== false) {
                         $output .= ',';
                     }

--- a/src/VarDumper.php
+++ b/src/VarDumper.php
@@ -2,7 +2,7 @@
 
 namespace Yiisoft\VarDumper;
 
-use Yiisoft\Arrays\ArrayableInterface;
+//use Yiisoft\{Arrays\ArrayHelper, Arrays\ArrayableTrait}, Yiisoft\Arrays\ArraySorter;
 
 /**
  * VarDumper is intended to replace the PHP functions var_dump and print_r.
@@ -383,6 +383,7 @@ final class VarDumper
         }
 
         --$start;
+        $uses = $this->parseUses(file($fileName));
 
         $source = implode("\n", array_slice(file($fileName), $start, $end - $start));
         $tokens = token_get_all('<?php ' . $source);
@@ -438,4 +439,5 @@ final class VarDumper
 
         return $tokens;
     }
+
 }

--- a/src/VarDumper.php
+++ b/src/VarDumper.php
@@ -426,23 +426,23 @@ final class VarDumper
                         $buffer = '';
                     }
                 }
-                if ($token === '}' || $token === ']') {
-                    $pendingParenthesisCount--;
-                    if ($pendingParenthesisCount === 0) {
-                        $closureTokens[] = $readableToken;
-                        break;
-                    }
-                    if ($pendingParenthesisCount < 0) {
-                        break;
-                    }
-                } elseif ($token === '{' || $token === '[') {
+                if ($token === '{' || $token === '[') {
                     $pendingParenthesisCount++;
+                } elseif ($token === '}' || $token === ']') {
+                    if ($pendingParenthesisCount === 0) {
+                        break;
+                    }
+                    $pendingParenthesisCount--;
+                } elseif ($token === ',' || $token === ';') {
+                    if ($pendingParenthesisCount === 0) {
+                        break;
+                    }
                 }
                 $closureTokens[] = $readableToken;
             }
         }
         if ($isShortClosure) {
-            $closureTokens= $this->cleanShortClosureTokens($closureTokens);
+            $closureTokens = $this->cleanShortClosureTokens($closureTokens);
         }
 
         return implode('', $closureTokens);

--- a/src/VarDumper.php
+++ b/src/VarDumper.php
@@ -441,9 +441,6 @@ final class VarDumper
                 $closureTokens[] = $readableToken;
             }
         }
-        if ($isShortClosure) {
-            $closureTokens = $this->cleanShortClosureTokens($closureTokens);
-        }
 
         return implode('', $closureTokens);
     }
@@ -453,18 +450,6 @@ final class VarDumper
         $this->exportClosureTokens = [T_FUNCTION, T_FN, T_STATIC];
         $this->beautify = false;
         return $this->export();
-    }
-
-    private function cleanShortClosureTokens(array $tokens): array
-    {
-        $count = count($tokens);
-        for ($i = $count; $i > 0; $i--) {
-            if ($tokens[$i - 1] === ',') {
-                return array_slice($tokens, 0, $i - 1);
-            }
-        }
-
-        return $tokens;
     }
 
     public function getUsesParser(): UseStatementParser

--- a/tests/UseStatementParserTest.php
+++ b/tests/UseStatementParserTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\VarDumper\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\VarDumper\UseStatementParser;
+
+class UseStatementParserTest extends TestCase
+{
+    /**
+     * @dataProvider usesProvider
+     */
+    public function testFromFile(string $file, array $expectedUses)
+    {
+        $parser = new UseStatementParser();
+
+        $actualUses = $parser->fromFile($file);
+
+        $this->assertEquals($expectedUses, $actualUses);
+    }
+
+    public function usesProvider(): array
+    {
+        /**
+         * use Yiisoft\Arrays\ArrayHelper;
+         * use Yiisoft\Arrays\ArrayHelper, Yiisoft\Arrays\ArraySorter;
+         * use Yiisoft\{Arrays\ArrayHelper, Arrays\ArrayableTrait};
+         * use Yiisoft\{Arrays\ArrayHelper, Arrays\ArrayableTrait}, Yiisoft\Arrays\ArraySorter;
+         */
+        return $this->saveExamplesToTemporaryFile([
+            [
+                'use Yiisoft\Arrays\ArrayHelper;',
+                ['\Yiisoft\Arrays\ArrayHelper'],
+            ],
+//            [
+//                'use Yiisoft\Arrays\ArrayHelper, Yiisoft\Arrays\ArraySorter;',
+//                [
+//                    '\Yiisoft\Arrays\ArrayHelper',
+//                    '\Yiisoft\Arrays\ArraySorter',
+//                ],
+//            ],
+//            [
+//                'use Yiisoft\{Arrays\ArrayHelper, Arrays\ArrayableTrait};',
+//                [
+//                    '\Yiisoft\Arrays\ArrayHelper',
+//                    '\Yiisoft\Arrays\ArrayableTrait',
+//                ],
+//            ],
+        ]);
+    }
+
+    public function saveExamplesToTemporaryFile(array $examples): array
+    {
+        static $handles = [];
+        foreach ($examples as &$example) {
+            $tmpFile = tmpfile();
+            $handles[] = $tmpFile;
+            fwrite($tmpFile, '<?php ' . $example[0]);
+
+            $example[0] = stream_get_meta_data($tmpFile)['uri'];
+        }
+
+        return $examples;
+    }
+}

--- a/tests/UseStatementParserTest.php
+++ b/tests/UseStatementParserTest.php
@@ -62,7 +62,7 @@ final class UseStatementParserTest extends TestCase
         ]);
     }
 
-    public function saveExamplesToTemporaryFile(array $examples): array
+    private function saveExamplesToTemporaryFile(array $examples): array
     {
         static $handles = [];
         foreach ($examples as &$example) {

--- a/tests/UseStatementParserTest.php
+++ b/tests/UseStatementParserTest.php
@@ -31,6 +31,17 @@ class UseStatementParserTest extends TestCase
          */
         return $this->saveExamplesToTemporaryFile([
             [
+                'use Yiisoft\Arrays\ArrayHelper as alias;',
+                ['alias' => '\Yiisoft\Arrays\ArrayHelper'],
+            ],
+            [
+                'use Yiisoft\Arrays\ArrayHelper as Helper, Yiisoft\Arrays\ArraySorter as Sorter;',
+                [
+                    'Helper' => '\Yiisoft\Arrays\ArrayHelper',
+                    'Sorter' => '\Yiisoft\Arrays\ArraySorter',
+                ],
+            ],
+            [
                 'use Yiisoft\Arrays\ArrayHelper;',
                 ['\Yiisoft\Arrays\ArrayHelper'],
             ],

--- a/tests/UseStatementParserTest.php
+++ b/tests/UseStatementParserTest.php
@@ -43,20 +43,20 @@ class UseStatementParserTest extends TestCase
             ],
             [
                 'use Yiisoft\Arrays\ArrayHelper;',
-                ['\Yiisoft\Arrays\ArrayHelper'],
+                ['ArrayHelper' => '\Yiisoft\Arrays\ArrayHelper'],
             ],
             [
                 'use Yiisoft\Arrays\ArrayHelper, Yiisoft\Arrays\ArraySorter;',
                 [
-                    '\Yiisoft\Arrays\ArrayHelper',
-                    '\Yiisoft\Arrays\ArraySorter',
+                    'ArrayHelper' => '\Yiisoft\Arrays\ArrayHelper',
+                    'ArraySorter' => '\Yiisoft\Arrays\ArraySorter',
                 ],
             ],
             [
                 'use Yiisoft\{Arrays\ArrayHelper, Arrays\ArrayableTrait};',
                 [
-                    '\Yiisoft\Arrays\ArrayHelper',
-                    '\Yiisoft\Arrays\ArrayableTrait',
+                    'ArrayHelper' => '\Yiisoft\Arrays\ArrayHelper',
+                    'ArrayableTrait' => '\Yiisoft\Arrays\ArrayableTrait',
                 ],
             ],
         ]);

--- a/tests/UseStatementParserTest.php
+++ b/tests/UseStatementParserTest.php
@@ -58,6 +58,7 @@ final class UseStatementParserTest extends TestCase
 
     private function saveExamplesToTemporaryFile(array $examples): array
     {
+        // Needed for tests. usesProvider provides temporary file that contains code from provider.
         static $handles = [];
         foreach ($examples as &$example) {
             $tmpFile = tmpfile();

--- a/tests/UseStatementParserTest.php
+++ b/tests/UseStatementParserTest.php
@@ -34,13 +34,13 @@ class UseStatementParserTest extends TestCase
                 'use Yiisoft\Arrays\ArrayHelper;',
                 ['\Yiisoft\Arrays\ArrayHelper'],
             ],
-//            [
-//                'use Yiisoft\Arrays\ArrayHelper, Yiisoft\Arrays\ArraySorter;',
-//                [
-//                    '\Yiisoft\Arrays\ArrayHelper',
-//                    '\Yiisoft\Arrays\ArraySorter',
-//                ],
-//            ],
+            [
+                'use Yiisoft\Arrays\ArrayHelper, Yiisoft\Arrays\ArraySorter;',
+                [
+                    '\Yiisoft\Arrays\ArrayHelper',
+                    '\Yiisoft\Arrays\ArraySorter',
+                ],
+            ],
 //            [
 //                'use Yiisoft\{Arrays\ArrayHelper, Arrays\ArrayableTrait};',
 //                [

--- a/tests/UseStatementParserTest.php
+++ b/tests/UseStatementParserTest.php
@@ -41,13 +41,13 @@ class UseStatementParserTest extends TestCase
                     '\Yiisoft\Arrays\ArraySorter',
                 ],
             ],
-//            [
-//                'use Yiisoft\{Arrays\ArrayHelper, Arrays\ArrayableTrait};',
-//                [
-//                    '\Yiisoft\Arrays\ArrayHelper',
-//                    '\Yiisoft\Arrays\ArrayableTrait',
-//                ],
-//            ],
+            [
+                'use Yiisoft\{Arrays\ArrayHelper, Arrays\ArrayableTrait};',
+                [
+                    '\Yiisoft\Arrays\ArrayHelper',
+                    '\Yiisoft\Arrays\ArrayableTrait',
+                ],
+            ],
         ]);
     }
 

--- a/tests/UseStatementParserTest.php
+++ b/tests/UseStatementParserTest.php
@@ -23,12 +23,6 @@ final class UseStatementParserTest extends TestCase
 
     public function usesProvider(): array
     {
-        /**
-         * use Yiisoft\Arrays\ArrayHelper;
-         * use Yiisoft\Arrays\ArrayHelper, Yiisoft\Arrays\ArraySorter;
-         * use Yiisoft\{Arrays\ArrayHelper, Arrays\ArrayableTrait};
-         * use Yiisoft\{Arrays\ArrayHelper, Arrays\ArrayableTrait}, Yiisoft\Arrays\ArraySorter;
-         */
         return $this->saveExamplesToTemporaryFile([
             [
                 'use Yiisoft\Arrays\ArrayHelper as alias;',

--- a/tests/VarDumperTest.php
+++ b/tests/VarDumperTest.php
@@ -202,7 +202,7 @@ RESULT;
         $var->name = 'Dmitry';
 
         $output = VarDumper::create($var)->asJson(50);
-        $this->assertEqualsWithoutLE('{"stdClass":{"name":"Dmitry"}}', $output);
+        $this->assertEqualsWithoutLE('{"stdClass":{"public::name":"Dmitry"}}', $output);
     }
 
     /**

--- a/tests/VarDumperTest.php
+++ b/tests/VarDumperTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use StdClass;
 use Yiisoft\VarDumper as VD;
 use Yiisoft\VarDumper\VarDumper;
+use Yiisoft\VarDumper\VarDumper as Dumper;
 
 /**
  * @group helpers
@@ -194,13 +195,19 @@ RESULT;
                 // @formatter:on
                 'fn () => 2',
             ],
-            'original'=>[
+            'original class name' => [
                 // @formatter:off
                 static fn (VarDumper $date) => new \DateTimeZone(''),
                 // @formatter:on
                 "static fn (\Yiisoft\VarDumper\VarDumper \$date) => new \DateTimeZone('')",
             ],
-            'namespace alias'=>[
+            'class alias' => [
+                // @formatter:off
+                static fn (Dumper $date) => new \DateTimeZone(''),
+                // @formatter:on
+                "static fn (\Yiisoft\VarDumper\VarDumper \$date) => new \DateTimeZone('')",
+            ],
+            'namespace alias' => [
                 // @formatter:off
                 static fn (VD\VarDumper $date) => new \DateTimeZone(''),
                 // @formatter:on

--- a/tests/VarDumperTest.php
+++ b/tests/VarDumperTest.php
@@ -45,6 +45,7 @@ class VarDumperTest extends TestCase
 
     /**
      * Data provider for [[testExport()]].
+     *
      * @return array test data
      */
     public function dataProviderExport(): array
@@ -155,6 +156,42 @@ RESULT;
         $exportResult = VarDumper::create($var)->export();
         $this->assertEqualsWithoutLE($expectedResult, $exportResult);
         //$this->assertEquals($var, eval('return ' . $exportResult . ';'));
+    }
+
+    /**
+     * @dataProvider asPhpStringDataProvider
+     *
+     * @param mixed $var
+     * @param string $expectedResult
+     */
+    public function testAsPhpString($var, $expectedResult): void
+    {
+        $exportResult = VarDumper::create($var)->asPhpString();
+        $this->assertEqualsWithoutLE($expectedResult, $exportResult);
+    }
+
+    public function asPhpStringDataProvider(): array
+    {
+        return [
+            [
+                // @formatter:off
+                static fn (VarDumper $date) => new \DateTimeZone(''),
+                // @formatter:on
+                "static fn (VarDumper \$date) => new \DateTimeZone('')",
+            ],
+            [
+                // @formatter:off
+                 static function () {return 2;},
+                // @formatter:on
+                'static function () {return 2;}',
+            ],
+            [
+                // @formatter:off
+                static fn () => 2,
+                // @formatter:on
+                'static fn () => 2',
+            ],
+        ];
     }
 
     /**

--- a/tests/VarDumperTest.php
+++ b/tests/VarDumperTest.php
@@ -4,6 +4,7 @@ namespace Yiisoft\VarDumper\Tests;
 
 use PHPUnit\Framework\TestCase;
 use StdClass;
+use Yiisoft\VarDumper as VD;
 use Yiisoft\VarDumper\VarDumper;
 
 /**
@@ -174,10 +175,12 @@ RESULT;
     {
         return [
             [
-                // @formatter:off
-                static fn (VarDumper $date) => new \DateTimeZone(''),
-                // @formatter:on
-                "static fn (VarDumper \$date) => new \DateTimeZone('')",
+                "123",
+                "'123'",
+            ],
+            [
+                123,
+                "123",
             ],
             [
                 // @formatter:off
@@ -187,9 +190,21 @@ RESULT;
             ],
             [
                 // @formatter:off
-                static fn () => 2,
+                 fn () => 2,
                 // @formatter:on
-                'static fn () => 2',
+                'fn () => 2',
+            ],
+            [
+                // @formatter:off
+                static fn (VarDumper $date) => new \DateTimeZone(''),
+                // @formatter:on
+                "static fn (\Yiisoft\VarDumper\VarDumper \$date) => new \DateTimeZone('')",
+            ],
+            [
+                // @formatter:off
+                static fn (VD\VarDumper $date) => new \DateTimeZone(''),
+                // @formatter:on
+                "static fn (\Yiisoft\VarDumper\VarDumper \$date) => new \DateTimeZone('')",
             ],
         ];
     }

--- a/tests/VarDumperTest.php
+++ b/tests/VarDumperTest.php
@@ -195,6 +195,12 @@ RESULT;
                 // @formatter:on
                 'fn () => 2',
             ],
+            'closure in array' => [
+                // @formatter:off
+                [fn () => new \DateTimeZone('')],
+                // @formatter:on
+                "[fn () => new \DateTimeZone('')]",
+            ],
             'original class name' => [
                 // @formatter:off
                 static fn (VarDumper $date) => new \DateTimeZone(''),

--- a/tests/VarDumperTest.php
+++ b/tests/VarDumperTest.php
@@ -219,6 +219,12 @@ RESULT;
                 // @formatter:on
                 "static fn (\Yiisoft\VarDumper\VarDumper \$date) => new \DateTimeZone('')",
             ],
+            'closure with null-collision operator' => [
+                // @formatter:off
+                fn () => $_ENV['var'] ?? null,
+                // @formatter:on
+                "fn () => \$_ENV['var'] ?? null",
+            ],
         ];
     }
 

--- a/tests/VarDumperTest.php
+++ b/tests/VarDumperTest.php
@@ -194,13 +194,13 @@ RESULT;
                 // @formatter:on
                 'fn () => 2',
             ],
-            [
+            'original'=>[
                 // @formatter:off
                 static fn (VarDumper $date) => new \DateTimeZone(''),
                 // @formatter:on
                 "static fn (\Yiisoft\VarDumper\VarDumper \$date) => new \DateTimeZone('')",
             ],
-            [
+            'namespace alias'=>[
                 // @formatter:off
                 static fn (VD\VarDumper $date) => new \DateTimeZone(''),
                 // @formatter:on


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌
| Depends on  | #9  

Now dumper will dump closures with usage `asPhpString()` method like the following:
![image](https://user-images.githubusercontent.com/6815714/96335193-a16b8000-107f-11eb-8f19-e5350a625421.png)
