### PR TITLE
Add test for closure exporting error

### DIFF
--- a/tests/VarDumperTest.php
+++ b/tests/VarDumperTest.php
@@ -191,6 +191,18 @@ RESULT;
                 // @formatter:on
                 'static fn () => 2',
             ],
+            [
+                // @formatter:off
+                [fn () => $params['test']],
+                // @formatter:on
+                "[fn () => \$params['test']]",
+            ],
+            [
+                // @formatter:off
+                [fn () => $params['test'],],
+                // @formatter:on
+                "[fn () => \$params['test'],]",
+            ],
         ];
     }
 


### PR DESCRIPTION
Found bug: exporting adds excessive square bracket `]`

Also it adds trailing comma in the end of array but it is not a problem.