### PR TITLE
Fix json dumping

### DIFF
--- a/tests/VarDumperTest.php
+++ b/tests/VarDumperTest.php
@@ -371,8 +371,8 @@ final class VarDumperTest extends TestCase
      */
     protected function assertEqualsWithoutLE(string $expected, string $actual, string $message = ''): void
     {
-        $expected = str_replace("\r\n", "\n", $expected);
-        $actual = str_replace("\r\n", "\n", $actual);
+        $expected = str_replace(["\r\n", '\r\n'], ["\n", '\n'], $expected);
+        $actual = str_replace(["\r\n", '\r\n'], ["\n", '\n'], $actual);
         $this->assertEquals($expected, $actual, $message);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️

1. Now `VarDumper::create($variable)->asJson()` will support any php types.
2. Json object dump provides object id (e.g. `"stdClass#1"`) **It breaks BC**