### PR TITLE
Small refactoring

### DIFF
--- a/src/VarDumper.php
+++ b/src/VarDumper.php
@@ -20,7 +20,7 @@ use Yiisoft\Arrays\ArrayableInterface;
 final class VarDumper
 {
     private $variable;
-    private static array $objects = [];
+    private array $objects = [];
 
     private ?ClosureExporter $closureExporter = null;
 
@@ -87,7 +87,7 @@ final class VarDumper
     {
         $this->buildObjectsCache($this->variable, $depth);
 
-        return $this->asJsonInternal(self::$objects, $prettyPrint, $depth, 1);
+        return $this->asJsonInternal($this->objects, $prettyPrint, $depth, 1);
     }
 
     /**
@@ -116,10 +116,10 @@ final class VarDumper
             return;
         }
         if (is_object($variable)) {
-            if (in_array($variable, self::$objects, true)) {
+            if (in_array($variable, $this->objects, true)) {
                 return;
             }
-            self::$objects[] = $variable;
+            $this->objects[] = $variable;
             $variable = $this->getObjectProperties($variable);
         }
         if (is_array($variable)) {
@@ -158,7 +158,7 @@ final class VarDumper
                     break;
                 }
 
-                if ($objectCollapseLevel < $level && in_array($var, self::$objects, true)) {
+                if ($objectCollapseLevel < $level && in_array($var, $this->objects, true)) {
                     $output = 'object@' . $objectDescription;
                     break;
                 }
@@ -261,7 +261,7 @@ final class VarDumper
                 if ($var instanceof \Closure) {
                     return $this->exportClosure($var);
                 }
-                if (in_array($var, self::$objects, true)) {
+                if (in_array($var, $this->objects, true)) {
                     return $this->getObjectDescription($var) . '(...)';
                 }
 
@@ -269,7 +269,7 @@ final class VarDumper
                     return get_class($var) . '(...)';
                 }
 
-                self::$objects[] = $var;
+                $this->objects[] = $var;
                 $spaces = str_repeat(' ', $level * 4);
                 $output = $this->getObjectDescription($var) . "\n" . $spaces . '(';
                 $objectProperties = $this->getObjectProperties($var);

--- a/src/VarDumper.php
+++ b/src/VarDumper.php
@@ -153,12 +153,13 @@ final class VarDumper
                     break;
                 }
 
-                if (($objectCollapseLevel < $level) && (in_array($var, self::$objects, true))) {
-                    if ($var instanceof \Closure) {
-                        $output = $this->exportClosure($var);
-                    } else {
-                        $output = 'object@' . $objectDescription;
-                    }
+                if ($var instanceof \Closure) {
+                    $output = [$objectDescription => $this->exportClosure($var)];
+                    break;
+                }
+
+                if ($objectCollapseLevel < $level && in_array($var, self::$objects, true)) {
+                    $output = 'object@' . $objectDescription;
                     break;
                 }
 
@@ -166,9 +167,10 @@ final class VarDumper
                 $properties = $this->getObjectProperties($var);
                 if (empty($properties)) {
                     $output[$objectDescription] = '{stateless object}';
+                    break;
                 }
                 foreach ($properties as $name => $value) {
-                    $keyDisplay = $this->normalizeProperty((string)$name);
+                    $keyDisplay = $this->normalizeProperty((string) $name);
                     /**
                      * @psalm-suppress InvalidArrayOffset
                      */

--- a/src/VarDumper.php
+++ b/src/VarDumper.php
@@ -194,14 +194,14 @@ final class VarDumper
         $property = str_replace("\0", '::', trim($property));
 
         if (strpos($property, '*::') === 0) {
-            return 'protected::' . substr($property, 3);
+            return 'protected $' . substr($property, 3);
         }
 
         if (($pos = strpos($property, '::')) !== false) {
-            return 'private::' . substr($property, $pos + 2);
+            return 'private $' . substr($property, $pos + 2);
         }
 
-        return 'public::' . $property;
+        return 'public $' . $property;
     }
 
     /**

--- a/tests/VarDumperTest.php
+++ b/tests/VarDumperTest.php
@@ -345,7 +345,7 @@ final class VarDumperTest extends TestCase
     public function testAsJsonObjectsMap($var, $expectedResult): void
     {
         $exportResult = VarDumper::create($var)->asJsonObjectsMap();
-        $this->assertStringContainsString($expectedResult, $exportResult);
+        $this->assertEquals($expectedResult, $exportResult);
     }
 
     public function asJsonObjectMapDataProvider(): array
@@ -363,13 +363,13 @@ final class VarDumperTest extends TestCase
             [
                 $user,
                 <<<S
-                "stdClass#{$objectId}":{"public \$id":1}
+                [{"stdClass#{$objectId}":{"public \$id":1}}]
                 S,
             ],
             [
                 $decoratedUser,
                 <<<S
-                "stdClass#{$decoratedObjectId}":{"public \$id":1,"public \$name":"Name","public \$originalUser":"object@stdClass#{$objectId}"}
+                [{"stdClass#{$decoratedObjectId}":{"public \$id":1,"public \$name":"Name","public \$originalUser":"object@stdClass#{$objectId}"}},{"stdClass#{$objectId}":{"public \$id":1}}]
                 S,
             ],
         ];

--- a/tests/VarDumperTest.php
+++ b/tests/VarDumperTest.php
@@ -405,6 +405,7 @@ final class VarDumperTest extends TestCase
         $objectWithClosureInProperty->a = fn () => 1;
         // @formatter:on
         $objectWithClosureInPropertyId = spl_object_id($objectWithClosureInProperty);
+        $objectWithClosureInPropertyClosureId = spl_object_id($objectWithClosureInProperty->a);
 
         $emptyObject = new stdClass();
         $emptyObjectId = spl_object_id($emptyObject);
@@ -453,6 +454,11 @@ final class VarDumperTest extends TestCase
         // @formatter:on
         $closureWithAliasedNamespaceObjectId = spl_object_id($closureWithAliasedNamespaceObject);
 
+        // @formatter:off
+        $closureInArrayObject = fn () => new \DateTimeZone('');
+        // @formatter:on
+        $closureInArrayObjectId = spl_object_id($closureInArrayObject);
+
         return [
             'empty object' => [
                 $emptyObject,
@@ -463,25 +469,25 @@ final class VarDumperTest extends TestCase
             'short function' => [
                 $shortFunctionObject,
                 <<<S
-                {"Closure#{$shortFunctionObjectId}":{"public $0":"fn () => 1"}}
+                {"Closure#{$shortFunctionObjectId}":"fn () => 1"}
                 S,
             ],
             'short static function' => [
                 $staticShortFunctionObject,
                 <<<S
-                {"Closure#{$staticShortFunctionObjectId}":{"public $0":"static fn () => 1"}}
+                {"Closure#{$staticShortFunctionObjectId}":"static fn () => 1"}
                 S,
             ],
             'function' => [
                 $functionObject,
                 <<<S
-                {"Closure#{$functionObjectId}":{"public $0":"function () {\\n            return 1;\\n        }"}}
+                {"Closure#{$functionObjectId}":"function () {\\n            return 1;\\n        }"}
                 S,
             ],
             'static function' => [
                 $staticFunctionObject,
                 <<<S
-                {"Closure#{$staticFunctionObjectId}":{"public $0":"static function () {\\n            return 1;\\n        }"}}
+                {"Closure#{$staticFunctionObjectId}":"static function () {\\n            return 1;\\n        }"}
                 S,
             ],
             'string' => [
@@ -534,32 +540,34 @@ final class VarDumperTest extends TestCase
             ],
             'closure in array' => [
                 // @formatter:off
-                [fn () => new \DateTimeZone('')],
+                [$closureInArrayObject],
                 // @formatter:on
-                '["fn () => new \\\DateTimeZone(\'\')"]',
+                <<<S
+                [{"Closure#{$closureInArrayObjectId}":"fn () => new \\\DateTimeZone('')"}]
+                S,
             ],
             'original class name' => [
                 $closureWithUsualClassNameObject,
                 <<<S
-                {"Closure#{$closureWithUsualClassNameObjectId}":{"public $0":"fn (\\\Yiisoft\\\VarDumper\\\VarDumper \$date) => new \\\DateTimeZone('')"}}
+                {"Closure#{$closureWithUsualClassNameObjectId}":"fn (\\\Yiisoft\\\VarDumper\\\VarDumper \$date) => new \\\DateTimeZone('')"}
                 S,
             ],
             'class alias' => [
                 $closureWithAliasedClassNameObject,
                 <<<S
-                {"Closure#{$closureWithAliasedClassNameObjectId}":{"public $0":"fn (\\\Yiisoft\\\VarDumper\\\VarDumper \$date) => new \\\DateTimeZone('')"}}
+                {"Closure#{$closureWithAliasedClassNameObjectId}":"fn (\\\Yiisoft\\\VarDumper\\\VarDumper \$date) => new \\\DateTimeZone('')"}
                 S,
             ],
             'namespace alias' => [
                 $closureWithAliasedNamespaceObject,
                 <<<S
-                {"Closure#{$closureWithAliasedNamespaceObjectId}":{"public $0":"fn (\\\Yiisoft\\\VarDumper\\\VarDumper \$date) => new \\\DateTimeZone('')"}}
+                {"Closure#{$closureWithAliasedNamespaceObjectId}":"fn (\\\Yiisoft\\\VarDumper\\\VarDumper \$date) => new \\\DateTimeZone('')"}
                 S,
             ],
             'closure with null-collision operator' => [
                 $closureWithNullCollisionOperatorObject,
                 <<<S
-                {"Closure#{$closureWithNullCollisionOperatorObjectId}":{"public $0":"fn () => \$_ENV['var'] ?? null"}}
+                {"Closure#{$closureWithNullCollisionOperatorObjectId}":"fn () => \$_ENV['var'] ?? null"}
                 S,
             ],
             'utf8 supported' => [
@@ -569,7 +577,7 @@ final class VarDumperTest extends TestCase
             'closure in property supported' => [
                 $objectWithClosureInProperty,
                 <<<S
-                {"stdClass#{$objectWithClosureInPropertyId}":{"public \$a":"fn () => 1"}}
+                {"stdClass#{$objectWithClosureInPropertyId}":{"public \$a":{"Closure#{$objectWithClosureInPropertyClosureId}":"fn () => 1"}}}
                 S,
             ],
             'binary string' => [

--- a/tests/VarDumperTest.php
+++ b/tests/VarDumperTest.php
@@ -363,13 +363,13 @@ final class VarDumperTest extends TestCase
             [
                 $user,
                 <<<S
-                "stdClass#{$objectId}":{"public::id":1}
+                "stdClass#{$objectId}":{"public \$id":1}
                 S,
             ],
             [
                 $decoratedUser,
                 <<<S
-                "stdClass#{$decoratedObjectId}":{"public::id":1,"public::name":"Name","public::originalUser":"object@stdClass#{$objectId}"}
+                "stdClass#{$decoratedObjectId}":{"public \$id":1,"public \$name":"Name","public \$originalUser":"object@stdClass#{$objectId}"}
                 S,
             ],
         ];
@@ -463,25 +463,25 @@ final class VarDumperTest extends TestCase
             'short function' => [
                 $shortFunctionObject,
                 <<<S
-                {"Closure#{$shortFunctionObjectId}":{"public::0":"fn () => 1"}}
+                {"Closure#{$shortFunctionObjectId}":{"public $0":"fn () => 1"}}
                 S,
             ],
             'short static function' => [
                 $staticShortFunctionObject,
                 <<<S
-                {"Closure#{$staticShortFunctionObjectId}":{"public::0":"static fn () => 1"}}
+                {"Closure#{$staticShortFunctionObjectId}":{"public $0":"static fn () => 1"}}
                 S,
             ],
             'function' => [
                 $functionObject,
                 <<<S
-                {"Closure#{$functionObjectId}":{"public::0":"function () {\\n            return 1;\\n        }"}}
+                {"Closure#{$functionObjectId}":{"public $0":"function () {\\n            return 1;\\n        }"}}
                 S,
             ],
             'static function' => [
                 $staticFunctionObject,
                 <<<S
-                {"Closure#{$staticFunctionObjectId}":{"public::0":"static function () {\\n            return 1;\\n        }"}}
+                {"Closure#{$staticFunctionObjectId}":{"public $0":"static function () {\\n            return 1;\\n        }"}}
                 S,
             ],
             'string' => [
@@ -541,25 +541,25 @@ final class VarDumperTest extends TestCase
             'original class name' => [
                 $closureWithUsualClassNameObject,
                 <<<S
-                {"Closure#{$closureWithUsualClassNameObjectId}":{"public::0":"fn (\\\Yiisoft\\\VarDumper\\\VarDumper \$date) => new \\\DateTimeZone('')"}}
+                {"Closure#{$closureWithUsualClassNameObjectId}":{"public $0":"fn (\\\Yiisoft\\\VarDumper\\\VarDumper \$date) => new \\\DateTimeZone('')"}}
                 S,
             ],
             'class alias' => [
                 $closureWithAliasedClassNameObject,
                 <<<S
-                {"Closure#{$closureWithAliasedClassNameObjectId}":{"public::0":"fn (\\\Yiisoft\\\VarDumper\\\VarDumper \$date) => new \\\DateTimeZone('')"}}
+                {"Closure#{$closureWithAliasedClassNameObjectId}":{"public $0":"fn (\\\Yiisoft\\\VarDumper\\\VarDumper \$date) => new \\\DateTimeZone('')"}}
                 S,
             ],
             'namespace alias' => [
                 $closureWithAliasedNamespaceObject,
                 <<<S
-                {"Closure#{$closureWithAliasedNamespaceObjectId}":{"public::0":"fn (\\\Yiisoft\\\VarDumper\\\VarDumper \$date) => new \\\DateTimeZone('')"}}
+                {"Closure#{$closureWithAliasedNamespaceObjectId}":{"public $0":"fn (\\\Yiisoft\\\VarDumper\\\VarDumper \$date) => new \\\DateTimeZone('')"}}
                 S,
             ],
             'closure with null-collision operator' => [
                 $closureWithNullCollisionOperatorObject,
                 <<<S
-                {"Closure#{$closureWithNullCollisionOperatorObjectId}":{"public::0":"fn () => \$_ENV['var'] ?? null"}}
+                {"Closure#{$closureWithNullCollisionOperatorObjectId}":{"public $0":"fn () => \$_ENV['var'] ?? null"}}
                 S,
             ],
             'utf8 supported' => [
@@ -569,7 +569,7 @@ final class VarDumperTest extends TestCase
             'closure in property supported' => [
                 $objectWithClosureInProperty,
                 <<<S
-                {"stdClass#{$objectWithClosureInPropertyId}":{"public::a":"fn () => 1"}}
+                {"stdClass#{$objectWithClosureInPropertyId}":{"public \$a":"fn () => 1"}}
                 S,
             ],
             'binary string' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️

Replaced `{visibility-modifier}::{property-name}` to `{visibility-modifier} ${property-name}` (like a php-style): e.g. `public::username` -> `public $username`
Wrapped raw closure's code with object: `"fn () => 1"` => `{"Closure#1":"fn () => 1"}`