### PR TITLE
Fix exporting closures with use long namespace under PHP 7.4 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 1.0.3 under development
 
-- no changes in this release.
+- Bug #50: Fix the issue of exporting closures with use long namespace under PHP 7.4 (devanych)
 
 
 ## 1.0.2 February 15, 2021

--- a/src/ClosureExporter.php
+++ b/src/ClosureExporter.php
@@ -91,16 +91,13 @@ final class ClosureExporter
                         continue;
                     }
                     $readableToken = $uses[$readableToken];
+                } elseif ($readableToken === '\\' && isset($tokens[$i - 1][1]) && $tokens[$i - 1][1] === '\\') {
+                    continue;
+                } elseif (isset($tokens[$i + 1]) && $this->useStatementParser->isTokenIsPartOfUse($tokens[$i + 1])) {
+                    $bufferUse .= $readableToken;
+                    continue;
                 }
                 if (!empty($bufferUse)) {
-                    $readableToken = '\\' . trim($readableToken, '\\');
-                    if ($readableToken === '\\') {
-                        continue;
-                    }
-                    if (isset($tokens[$i + 2]) && $this->useStatementParser->isTokenIsPartOfUse($tokens[$i + 2])) {
-                        $bufferUse .= $readableToken;
-                        continue;
-                    }
                     if ($bufferUse !== $readableToken && strpos($readableToken, $bufferUse) === false) {
                         $readableToken = $bufferUse . $readableToken;
                     }

--- a/tests/ClosureExporterTest.php
+++ b/tests/ClosureExporterTest.php
@@ -81,4 +81,11 @@ final class ClosureExporterTest extends TestCase
         $output = $exporter->export(fn (\E\F\G\H\I\J\K\L\M\N $date) => new DateTimeZone(''));
         $this->assertSame("fn (\E\F\G\H\I\J\K\L\M\N \$date) => new \DateTimeZone('')", $output);
     }
+
+    public function testLongWithExistingImport(): void
+    {
+        $exporter = new ClosureExporter();
+        $output = $exporter->export(fn (\Yiisoft\VarDumper\ClosureExporter $date) => new DateTimeZone(''));
+        $this->assertSame("fn (\Yiisoft\VarDumper\ClosureExporter \$date) => new \DateTimeZone('')", $output);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
