### PR TITLE
Removed leading spaces in closure dumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.5.1 under development
 
-- no changes in this release.
+- Enh #88: Removed leading spaces in closure dumps (@xepozz)
 
 ## 1.5.0 January 16, 2023
 

--- a/src/ClosureExporter.php
+++ b/src/ClosureExporter.php
@@ -63,7 +63,7 @@ final class ClosureExporter
 
         --$start;
         $uses = $this->useStatementParser->fromFile($fileName);
-        $tokens = token_get_all('<?php ' . PHP_EOL . implode('', array_slice($fileContent, $start, $end - $start)));
+        $tokens = token_get_all('<?php ' . implode('', array_slice($fileContent, $start, $end - $start)));
         array_shift($tokens);
 
         $bufferUse = '';

--- a/tests/ClosureExporterTest.php
+++ b/tests/ClosureExporterTest.php
@@ -19,9 +19,14 @@ final class ClosureExporterTest extends TestCase
             return 42 + $test;
         });
 
-        $this->assertEquals('function (int $test): int {
-            return 42 + $test;
-        }', $output);
+        $this->assertEquals(
+            <<<PHP
+            function (int \$test): int {
+                return 42 + \$test;
+            }
+            PHP,
+            $output
+        );
     }
 
     public function testStatic(): void
@@ -31,9 +36,14 @@ final class ClosureExporterTest extends TestCase
             return 42 + $test;
         });
 
-        $this->assertEquals('static function (int $test): int {
-            return 42 + $test;
-        }', $output);
+        $this->assertEquals(
+            <<<PHP
+            static function (int \$test): int {
+                return 42 + \$test;
+            }
+            PHP,
+            $output
+        );
     }
 
     public function testShort(): void

--- a/tests/VarDumperTest.php
+++ b/tests/VarDumperTest.php
@@ -103,17 +103,21 @@ final class VarDumperTest extends TestCase
                 function () {
                     return 1;
                 },
-                'function () {
+                <<<PHP
+                function () {
                     return 1;
-                }',
+                }
+                PHP,
             ],
             'static function' => [
                 static function () {
                     return 1;
                 },
-                'static function () {
+                <<<PHP
+                static function () {
                     return 1;
-                }',
+                }
+                PHP,
             ],
             'string' => [
                 'Hello, Yii!',
@@ -255,17 +259,21 @@ final class VarDumperTest extends TestCase
                 function () {
                     return 1;
                 },
-                'function () {
+                <<<PHP
+                function () {
                     return 1;
-                }',
+                }
+                PHP,
             ],
             'static function' => [
                 static function () {
                     return 1;
                 },
-                'static function () {
+                <<<PHP
+                static function () {
                     return 1;
-                }',
+                }
+                PHP,
             ],
             'string' => [
                 'Hello, Yii!',
@@ -654,17 +662,21 @@ final class VarDumperTest extends TestCase
                 function () {
                     return 1;
                 },
-                'function () {
+                <<<PHP
+                function () {
                     return 1;
-                }',
+                }
+                PHP,
             ],
             'static function' => [
                 static function () {
                     return 1;
                 },
-                'static function () {
+                <<<PHP
+                static function () {
                     return 1;
-                }',
+                }
+                PHP,
             ],
             'string' => [
                 'Hello, Yii!',
@@ -885,7 +897,7 @@ final class VarDumperTest extends TestCase
                     return 1;
                 },
                 <<<JSON
-                "function () {\\n                    return 1;\\n                }"
+                "function () {\\n    return 1;\\n}"
                 JSON,
             ],
             'static function' => [
@@ -893,7 +905,7 @@ final class VarDumperTest extends TestCase
                     return 1;
                 },
                 <<<JSON
-                "static function () {\\n                    return 1;\\n                }"
+                "static function () {\\n    return 1;\\n}"
                 JSON,
             ],
             'string' => [
@@ -1185,17 +1197,21 @@ final class VarDumperTest extends TestCase
                 function () {
                     return 1;
                 },
-                'function () {
+                <<<PHP
+                function () {
                     return 1;
-                }',
+                }
+                PHP,
             ],
             'static function' => [
                 static function () {
                     return 1;
                 },
-                'static function () {
+                <<<PHP
+                static function () {
                     return 1;
-                }',
+                }
+                PHP,
             ],
             'string' => [
                 'Hello, Yii!',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


**Before:**
```
function () {
        return 1;
    }
```
**After:**
```
function () {
    return 1;
}
```